### PR TITLE
Fix failed dotnet publish

### DIFF
--- a/mod10/deploy.sh
+++ b/mod10/deploy.sh
@@ -36,7 +36,7 @@ sleep .5
 # Publish and start application
 
 cd /tailwind/Source/Tailwind.Traders.Web
-dotnet publish -c Release
+sudo dotnet publish -c Release
 dotnet bin/Release/netcoreapp2.1/publish/Tailwind.Traders.Web.dll &
 
 sleep .5


### PR DESCRIPTION
Without 'sudo' the publish process fails with error: 

Unable to save binary /tailwind/Source/Tailwind.Traders.Web/ClientApp/node_modules/node-sass/vendor/linux-x64-57 : { error : EACCES: permission denied, mkdir '/tailwind/Source/Tailwind.Traders.Web/ClientApp/node_modules/node-sass/vendor' [/tailwind/Source/Tailwind.Traders.Web/Tailwind.Traders.Web.csproj]