### PR TITLE
Support special characters in init script

### DIFF
--- a/mod20/DeploymentTemplates/azuredeploy-vms.json
+++ b/mod20/DeploymentTemplates/azuredeploy-vms.json
@@ -420,7 +420,7 @@
 						]
 					},
 					"protectedSettings": {
-						"commandToExecute": "[concat('sudo sh configure-mongo.sh ', parameters('username'), ' ', parameters('password'))]"
+						"commandToExecute": "[concat('sudo sh configure-mongo.sh \"', replace(parameters('username'),'\"','\\\"'), '\" \"', replace(parameters('password'),'\"','\\\"'), '\"')]"
 					}
 				}
 			}]


### PR DESCRIPTION
If a username or password is supplied that contains certain special characters then the Mongo VM provisioning will fail. This change fixes the command to be more robust.