### PR TITLE
Fix permission errors when running deploy.sh

### DIFF
--- a/mod10/deployment.md
+++ b/mod10/deployment.md
@@ -127,7 +127,7 @@ The next step is to download the deployment script to the VM, update it, and fin
 To elevate the current user as super and get the script `deploy.sh` execute the following commands.
 
 ```bash
-sudo su
+sudo su -l
 curl https://raw.githubusercontent.com/microsoft/ignite-learning-paths-training-mod/master/mod10/deploy.sh >deploy.sh
 ```
 


### PR DESCRIPTION
Without the `-l` parameter for `sudo su` the deploy script gives "permission denied" errors when attempting to publish the app.