### PR TITLE
Update NodeJS to 10X

### DIFF
--- a/mod10/deploy.sh
+++ b/mod10/deploy.sh
@@ -17,7 +17,7 @@ add-apt-repository universe
 apt-get update
 apt-get install apt-transport-https
 apt-get install dotnet-sdk-2.2=2.2.102-1 -y
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
 


### PR DESCRIPTION
Removes warning due to EOL for Node 8. Does not impact functioning of site.