### PR TITLE
Fix error with sed; run dotnet as root

### DIFF
--- a/mod10/deploy.sh
+++ b/mod10/deploy.sh
@@ -17,7 +17,7 @@ add-apt-repository universe
 apt-get update
 apt-get install apt-transport-https
 apt-get install dotnet-sdk-2.2=2.2.102-1 -y
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
 

--- a/mod10/deploy.sh
+++ b/mod10/deploy.sh
@@ -37,9 +37,9 @@ sleep .5
 
 cd /tailwind/Source/Tailwind.Traders.Web
 sudo sed -i 's/http\:\/\/localhost\:5200\/v1/\/api\/v1/' appsettings.json
-sudo sed -i 's/http\:\/\/localhost\:3000/\/api/v1/' appsettings.json
-dotnet publish -c Release
-dotnet bin/Release/netcoreapp2.1/publish/Tailwind.Traders.Web.dll 1>/dev/null 2>&1 </dev/null &
+sudo sed -i 's/http\:\/\/localhost\:3000/\/api\/v1/' appsettings.json
+sudo dotnet publish -c Release
+sudo dotnet bin/Release/netcoreapp2.1/publish/Tailwind.Traders.Web.dll 1>/dev/null 2>&1 </dev/null &
 
 sleep .5
 


### PR DESCRIPTION
The 'sed' command was missing an escape character. The dotnet commands failed due to ownership of /tailwind folder and also due to the web app needing to bind to port 80.